### PR TITLE
fix: update kube-ovn-webhook with the upstream

### DIFF
--- a/internal/templates/deployments.go
+++ b/internal/templates/deployments.go
@@ -763,7 +763,10 @@ spec:
                   app: kube-ovn-webhook
               topologyKey: kubernetes.io/hostname
       serviceAccountName: ovn
-      hostNetwork: true
+      automountServiceAccountToken: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: kube-ovn-webhook
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

v1.15.4 kube-ovn-webhook fails to start due to the following error:

```
I0401 06:41:35.189563       1 server.go:40] 
-------------------------------------------------------------------------------
Kube-OVN: 
  Version:       v1.15.4
  Build:         2026-02-12_06:22:45
  Commit:        git-5b263ed
  Go Version:    go1.25.7
  Arch:          amd64
-------------------------------------------------------------------------------
E0401 06:41:35.190151       1 config.go:138] "unable to load in-cluster config" err="open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory" logger="controller-runtime.client.config"
E0401 06:41:35.190846       1 config.go:185] "unable to get kubeconfig" err="invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable" logger="controller-runtime.client.config"
stream closed: EOF for kube-system/kube-ovn-webhook-5f57557cb-824kr (kube-ovn-webhook)
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The key missing part is the automountServiceAccountToken. Without it, the webhook won't be able to find the in-cluster config to access the API server.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
