### PR TITLE
chore: bump golang 1.26

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Run build and test
         run: make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.suse.com/bci/golang:1.25.7 AS builder
+FROM registry.suse.com/bci/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.20.1
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/harvester/kubeovn-operator
 
-go 1.25.7
+go 1.26
 
-godebug default=go1.25.7
+godebug default=go1.26.3
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
    - also bump golangci-lint 2.12.2

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
bump golang 1.26

**Solution:**
bump golang 1.26

**Related Issue:**
https://github.com/harvester/harvester/issues/10734

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
